### PR TITLE
Fix output cleanup and show local run

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ A Flask app that uses a local Hugging Face model to tailor your `.docx` resume f
 ```bash
 docker build -t resume-tailor .
 docker run -p 5000:5000 resume-tailor
+```
+
+## Local Testing (Python)
+```bash
+pip install -r requirements.txt
+python app.py
+```


### PR DESCRIPTION
## Summary
- ensure generated files are removed after download
- allow `python app.py` to run directly
- document installing requirements for local testing

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687580e53a58832e9a10074ea9f508a2